### PR TITLE
All rhub all the time.

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,9 @@
 ## Test environments
 * local R installation, R 4.1.1 (Windows)
 * collaborator R installation, R 4.0.0 (Mac)
-* win-builder (devel)
+* Windows Server 2008 R2 SP1, R-devel, 32/64 bit (rhub)
+* Ubuntu Linux 20.04.1 LTS, R-release, GCC (rhub)
+* Fedora Linux, R-devel, clang, gfortran (rhub)
 
 ## R CMD check results
 


### PR DESCRIPTION
devtools::check_win_devel() is failing today. It looks to me like a drive is disconnected or maybe full. But RHUB has a win devel check included, so... I think we're good.